### PR TITLE
Deprecate Elastic Stack

### DIFF
--- a/content/kubermatic/master/changelog/2.13/_index.en.md
+++ b/content/kubermatic/master/changelog/2.13/_index.en.md
@@ -8,8 +8,8 @@ pre = "<b></b>"
 
 ## v2.13.0
 
-
 Supported Kubernetes versions:
+
 - `1.15.5`
 - `1.15.6`
 - `1.15.7`
@@ -22,7 +22,8 @@ Supported Kubernetes versions:
 - `1.17.2`
 - Openshift `v4.1.18`
 
-**Major changes:**
+#### Major changes
+
 - End-of-Life Kubernetes v1.14 is no longer supported.
 - The `authorized_keys` files on nodes are now updated whenever the SSH keys for a cluster are changed
 - Added support for custom CA for OpenID provider in Kubermatic API.
@@ -33,7 +34,8 @@ Supported Kubernetes versions:
 - Added RedHat Enterprise Linux as an OS option (#669)
 - Added SUSE Linux Enterprise Server as an OS option (#659)
 
-**Cloud providers:**
+#### Cloud providers
+
 - Openstack: A bug that caused cluster reconciliation to fail if the controller crashed at the wrong time was fixed
 - Openstack: New Kubernetes 1.16&#43; clusters use the external Cloud Controller Manager and CSI by default
 - vSphere: Fixed a bug that resulted in a faulty cloud config when using a non-default port
@@ -43,8 +45,8 @@ Supported Kubernetes versions:
 - Azure: Node sizes are displayed in size dropdown when creating/updating a node deployment
 - GCP: Networks are fetched from API now
 
+#### Bugfixes
 
-**Bugfixes:**
 - Fixed parsing Kibana's logs in Fluent-Bit
 - Fixed master-controller failing to create project-label-synchronizer controllers.
 - Fixed broken NodePort-Proxy for user clusters with LoadBalancer expose strategy.
@@ -60,7 +62,8 @@ Supported Kubernetes versions:
 - Fixed deleting user-selectable addons from clusters.
 - Fixed node name validation while creating clusters and node deployments
 
-**UI:**
+#### UI
+
 - ACTION REQUIRED: Added logos and descriptions for the addons. In order to see the logos and descriptions addons have to be configured with AddonConfig CRDs with the same names as addons.
 - ACTION REQUIRED: Added application settings view. Some of the settings were moved from config map to the `KubermaticSettings` CRD. In order to use them in the UI it is required to manually update the CRD or do it from newly added UI.
 - Fixed label form validator.
@@ -74,14 +77,16 @@ Supported Kubernetes versions:
 - Restyled some elements in the admin panel.
 - Added separate save indicators for custom links in the admin panel.
 
-**Addons:**
+#### Addons
+
 - The dashboard addon was removed as it's now deployed in the seed and can be used via its proxy endpoint
 - Added default namespace/cluster roles for addons
 - Introduced addon configurations.
 - Fixed addon config get and list endpoints.
 - Added forms for addon variables.
 
-**Misc:**
+#### Misc
+
 - ACTION REQUIRED: Updated cert-manager to 0.12.0. This requires a full reinstall of the chart. See https://cert-manager.io/docs/installation/upgrading/upgrading-0.10-0.11/
 - Updated Alertmanager to 0.20.0
 - Update Kubernetes Dashboard to v2.0.0-rc3

--- a/content/kubermatic/master/upgrading/2.12_to_2.13/_index.en.md
+++ b/content/kubermatic/master/upgrading/2.12_to_2.13/_index.en.md
@@ -1,0 +1,26 @@
++++
+title = "Upgrading from 2.12 to 2.13"
+date = 2020-02-13T11:09:15+02:00
+weight = 70
+pre = "<b></b>"
++++
+
+## Helm Charts
+
+### cert-manager
+
+Kubermatic 2.13 ships with cert-manager 0.12, which changed the API group for its CRDs from `certmanager.k8s.io` to
+`cert-manager.io`. This requires manual intervention and a short time frame where no certificates can be created when
+upgrading. Before upgrading, create a backup of all cert-manager resources (certificates, issuers, ...) because their
+CRDs will have to be recreated.
+
+After creating the backup, delete the cert-manager chart, delete the CRDs and re-install the chart (which also
+re-installs the CRDs):
+
+```bash
+helm --tiller-namespace kubermatic-installer delete --purge cert-manager
+kubectl get crd | awk '/certmanager/ {print $1}' | xargs kubectl delete crd
+
+cd kubermatic-installer/charts/cert-manager
+helm --tiller-namespace kubermatic-installer upgrade --install --namespace cert-manager --values YOUR_VALUES_YAML_HERE cert-manager .
+```

--- a/content/kubermatic/master/upgrading/2.13_to_2.14/_index.en.md
+++ b/content/kubermatic/master/upgrading/2.13_to_2.14/_index.en.md
@@ -1,0 +1,6 @@
++++
+title = "Upgrading from 2.13 to 2.14"
+date = 2020-02-13T11:09:15+02:00
+weight = 80
+pre = "<b></b>"
++++

--- a/content/kubermatic/master/upgrading/2.13_to_2.14/_index.en.md
+++ b/content/kubermatic/master/upgrading/2.13_to_2.14/_index.en.md
@@ -4,3 +4,27 @@ date = 2020-02-13T11:09:15+02:00
 weight = 80
 pre = "<b></b>"
 +++
+
+## Helm Charts
+
+### Elastic Stack
+
+Kubermatic 2.14 deprecates the Elasticsearch-based logging stack, consisting of the `elasticsearch`, `kibana` and `fluentbit`
+Helm charts. These components will only receive security fixes in future releases and will be removed entirely in version
+2.16.
+
+Log aggregation in Kubermatic is now handled by [Grafana Loki](https://grafana.com/oss/loki/), offering a much simpler and
+less resource intensive setup. As existing data cannot be migrated into Loki, it's recommended to install Loki in parallel
+to an existing ELK stack and ship logs only to it going forward. Once all logs in Elasticsearch have expired, the Elastic
+Stack can be deleted.
+
+Loki can be setup by installing two Helm charts:
+
+```bash
+helm upgrade --tiller-namespace kubermatic --install --values YOUR_VALUES_YAML_HERE --namespace logging loki charts/logging/loki/
+helm upgrade --tiller-namespace kubermatic --install --values YOUR_VALUES_YAML_HERE --namespace logging promtail charts/logging/promtail/
+```
+
+An alternative to Loki is the [Elastic Cloud on Kubernetes (ECK)](https://www.elastic.co/elastic-cloud-kubernetes) stack,
+which greatly simplifies managing Elasticsearch clusters on Kubernetes. Like with Loki, there is no migration planned and
+customers are advised to install an ECK stack in parallel to slowly phase out the old, Helm-based stack.

--- a/content/kubermatic/v2.13/changelog/2.13/_index.en.md
+++ b/content/kubermatic/v2.13/changelog/2.13/_index.en.md
@@ -8,8 +8,8 @@ pre = "<b></b>"
 
 ## v2.13.0
 
-
 Supported Kubernetes versions:
+
 - `1.15.5`
 - `1.15.6`
 - `1.15.7`
@@ -22,7 +22,8 @@ Supported Kubernetes versions:
 - `1.17.2`
 - Openshift `v4.1.18`
 
-**Major changes:**
+#### Major changes
+
 - End-of-Life Kubernetes v1.14 is no longer supported.
 - The `authorized_keys` files on nodes are now updated whenever the SSH keys for a cluster are changed
 - Added support for custom CA for OpenID provider in Kubermatic API.
@@ -33,7 +34,8 @@ Supported Kubernetes versions:
 - Added RedHat Enterprise Linux as an OS option (#669)
 - Added SUSE Linux Enterprise Server as an OS option (#659)
 
-**Cloud providers:**
+#### Cloud providers
+
 - Openstack: A bug that caused cluster reconciliation to fail if the controller crashed at the wrong time was fixed
 - Openstack: New Kubernetes 1.16&#43; clusters use the external Cloud Controller Manager and CSI by default
 - vSphere: Fixed a bug that resulted in a faulty cloud config when using a non-default port
@@ -43,8 +45,8 @@ Supported Kubernetes versions:
 - Azure: Node sizes are displayed in size dropdown when creating/updating a node deployment
 - GCP: Networks are fetched from API now
 
+#### Bugfixes
 
-**Bugfixes:**
 - Fixed parsing Kibana's logs in Fluent-Bit
 - Fixed master-controller failing to create project-label-synchronizer controllers.
 - Fixed broken NodePort-Proxy for user clusters with LoadBalancer expose strategy.
@@ -60,7 +62,8 @@ Supported Kubernetes versions:
 - Fixed deleting user-selectable addons from clusters.
 - Fixed node name validation while creating clusters and node deployments
 
-**UI:**
+#### UI
+
 - ACTION REQUIRED: Added logos and descriptions for the addons. In order to see the logos and descriptions addons have to be configured with AddonConfig CRDs with the same names as addons.
 - ACTION REQUIRED: Added application settings view. Some of the settings were moved from config map to the `KubermaticSettings` CRD. In order to use them in the UI it is required to manually update the CRD or do it from newly added UI.
 - Fixed label form validator.
@@ -74,14 +77,16 @@ Supported Kubernetes versions:
 - Restyled some elements in the admin panel.
 - Added separate save indicators for custom links in the admin panel.
 
-**Addons:**
+#### Addons
+
 - The dashboard addon was removed as it's now deployed in the seed and can be used via its proxy endpoint
 - Added default namespace/cluster roles for addons
 - Introduced addon configurations.
 - Fixed addon config get and list endpoints.
 - Added forms for addon variables.
 
-**Misc:**
+#### Misc
+
 - ACTION REQUIRED: Updated cert-manager to 0.12.0. This requires a full reinstall of the chart. See https://cert-manager.io/docs/installation/upgrading/upgrading-0.10-0.11/
 - Updated Alertmanager to 0.20.0
 - Update Kubernetes Dashboard to v2.0.0-rc3

--- a/content/kubermatic/v2.13/upgrading/2.12_to_2.13/_index.en.md
+++ b/content/kubermatic/v2.13/upgrading/2.12_to_2.13/_index.en.md
@@ -1,0 +1,26 @@
++++
+title = "Upgrading from 2.12 to 2.13"
+date = 2020-02-13T11:09:15+02:00
+weight = 70
+pre = "<b></b>"
++++
+
+## Helm Charts
+
+### cert-manager
+
+Kubermatic 2.13 ships with cert-manager 0.12, which changed the API group for its CRDs from `certmanager.k8s.io` to
+`cert-manager.io`. This requires manual intervention and a short time frame where no certificates can be created when
+upgrading. Before upgrading, create a backup of all cert-manager resources (certificates, issuers, ...) because their
+CRDs will have to be recreated.
+
+After creating the backup, delete the cert-manager chart, delete the CRDs and re-install the chart (which also
+re-installs the CRDs):
+
+```bash
+helm --tiller-namespace kubermatic-installer delete --purge cert-manager
+kubectl get crd | awk '/certmanager/ {print $1}' | xargs kubectl delete crd
+
+cd kubermatic-installer/charts/cert-manager
+helm --tiller-namespace kubermatic-installer upgrade --install --namespace cert-manager --values YOUR_VALUES_YAML_HERE cert-manager .
+```


### PR DESCRIPTION
This makes our divorce from ELK official, fixes the layout of the 2.13 changelog and provides an upgrade guide for 2.13.