### PR TITLE
Fix bad page title

### DIFF
--- a/content/kubermatic/master/_index.en.md
+++ b/content/kubermatic/master/_index.en.md
@@ -1,10 +1,8 @@
 +++
-title = "Kubermatic"
+title = "Welcome"
 date = 2019-08-26T16:06:34+02:00
 weight = 5
 +++
-
-# Welcome to Kubermatic Docs
 
 ## One Enterprise Kubernetes Management Platform For Any Infrastructure
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -6,7 +6,7 @@
     {{ hugo.Generator }}
     {{ partial "meta.html" . }}
     {{ partial "favicon.html" . }}
-    <title>{{ .Title }} :: {{ .Site.Title }}</title>
+    <title>{{ .Title }} - {{ partial "title.html" . }}</title>
 
     {{ $assetBusting := not .Site.Params.disableAssetsBusting }}
     <link href="{{"css/nucleus.css" | relURL}}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}" rel="stylesheet">

--- a/layouts/partials/title.html
+++ b/layouts/partials/title.html
@@ -1,0 +1,5 @@
+{{- if eq .Page.Section "kubermatic" -}}
+Kubermatic Documentation
+{{- else -}}
+Loodse Documentation
+{{- end -}}


### PR DESCRIPTION
This fixes the bad `Kubermatic :: Documentation for` title in our documentation. There is (to my knowledge) no good way of just setting a config variable / parameter / whatever *per directory*, so I made a switch based on the root directory (the section name).