### PR TITLE
Document the certificate changes in 2.14

### DIFF
--- a/content/kubermatic/master/upgrading/2.13_to_2.14/_index.en.md
+++ b/content/kubermatic/master/upgrading/2.13_to_2.14/_index.en.md
@@ -28,3 +28,21 @@ helm upgrade --tiller-namespace kubermatic --install --values YOUR_VALUES_YAML_H
 An alternative to Loki is the [Elastic Cloud on Kubernetes (ECK)](https://www.elastic.co/elastic-cloud-kubernetes) stack,
 which greatly simplifies managing Elasticsearch clusters on Kubernetes. Like with Loki, there is no migration planned and
 customers are advised to install an ECK stack in parallel to slowly phase out the old, Helm-based stack.
+
+### Certificates
+
+Previously, Kubermatic used a shared Helm chart, `certs`, that contains all TLS certificates for both Kubermatic and all
+IAP Ingresses. This however made the configuration somewhat hard to understand and does not work well with the new
+Kubermatic Operator.
+
+For these reasons the `certs` chart is now deprecated. Instead the `kubermatic` and `iap` charts will create their own
+certificates and reference them explicitly in the Ingresses they also create. The `--default-ssl-certificate` CLI flag
+for nginx is now not set anymore.
+
+To upgrade, just upgrade the `kubermatic` and `iap` charts as normal. Make sure to have the current `cert-manager` installed
+and configured to create a `letsencrypt-prod` ClusterIssuer (which it does by default). After upgrading the charts, it should
+only take a minute for the new certificates to be acquired.
+
+The `certs` chart can be removed entirely from the cluster. You might also want to manually remove the
+`kubermatic/kubermatic-tls-certificates` Secret, as it will soon expire. If you used the `certs` chart to manage
+non-Kubermatic/IAP certificates, please migrate accordingly as the chart will soon not be published with Kubermatic anymore.


### PR DESCRIPTION
https://github.com/kubermatic/kubermatic/pull/5163 deprecates the `certs` chart, this PR adds an upgrade note for this.