### PR TITLE
Make logo redirect to the landing page

### DIFF
--- a/layouts/partials/logo.html
+++ b/layouts/partials/logo.html
@@ -1,7 +1,9 @@
 {{ range $key, $value := $.Site.Data.version }}
-	{{ if in $.RelPermalink $key }}
-		<a href="{{ .Site.BaseURL }}">
-			<img src="{{ .Site.BaseURL }}/{{ $value.logo }}" alt="Kubermatic">
-		</a>
-	{{ end }}
+    {{ with $.Site.GetPage (printf "/%s" $key) }}
+        {{ if hasPrefix $.RelPermalink .RelPermalink }}
+        <a href="{{ .RelPermalink }}">
+            <img src="/{{ $value.logo }}" alt="{{ $value.name }}">
+        </a>
+        {{ end }}
+    {{ end }}
 {{ end }}


### PR DESCRIPTION
This PR makes the logo redirect to the landing page instead of to the current page.

This implementation redirects to the default version instead of the previously selected version, because I'm not sure how to find out which version was selected.