### PR TITLE
Update Hugo to v0.68.3

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,8 @@
 [context.production.environment]
-HUGO_VERSION = "0.58.3"
+HUGO_VERSION = "0.68.3"
 
 [context.deploy-preview]
 command = "hugo -D -F -b $DEPLOY_PRIME_URL"
 
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.58.3"
+HUGO_VERSION = "0.68.3"


### PR DESCRIPTION
This PR updates Hugo to the latest version (v0.68.3). This should solve the rendering issues we are having with the KubeOne docs.